### PR TITLE
A few improvements to the gemspec for dependency management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
-gem "rspec"
-gem "rspec"
-gem "webmock"
-gem "braintreehttp", '0.5.0'
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+PATH
+  remote: .
+  specs:
+    paypal-checkout-sdk (1.0.1)
+      braintreehttp (~> 0.5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -32,9 +38,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  braintreehttp (= 0.5.0)
+  paypal-checkout-sdk!
   rspec
   webmock
 
 BUNDLED WITH
-   1.16.4
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    paypal-checkout-sdk (1.0.1)
-      braintreehttp (~> 0.5.0)
+    paypal-checkout-sdk (1.0.2)
+      braintreehttp (~> 0.5)
 
 GEM
   remote: https://rubygems.org/
@@ -15,6 +15,7 @@ GEM
     diff-lcs (1.3)
     hashdiff (0.3.7)
     public_suffix (3.0.3)
+    rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -39,7 +40,8 @@ PLATFORMS
 
 DEPENDENCIES
   paypal-checkout-sdk!
-  rspec
+  rake (~> 10.0)
+  rspec (~> 3.0)
   webmock
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/lib/core/version.rb
+++ b/lib/core/version.rb
@@ -1,3 +1,3 @@
 module PayPal
-  VERSION = "1.0.0"
+  VERSION = "1.0.2"
 end

--- a/paypal-checkout-sdk.gemspec
+++ b/paypal-checkout-sdk.gemspec
@@ -10,4 +10,9 @@ Gem::Specification.new do |s|
   s.homepage    =
     'https://github.com/paypal/Checkout-Ruby-SDK'
   s.license       = 'MIT'
+
+  s.add_dependency 'braintreehttp', '~> 0.5.0'
+
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'webmock'
 end

--- a/paypal-checkout-sdk.gemspec
+++ b/paypal-checkout-sdk.gemspec
@@ -1,18 +1,27 @@
-Gem::Specification.new do |s|
-  s.name        = 'paypal-checkout-sdk'
-  s.version     = '1.0.1'
-  s.date        = '2018-02-04'
-  s.summary     = "This repository contains PayPal's Ruby SDK for Checkout REST API"
-  s.description = "This repository contains PayPal's Ruby SDK for Checkout REST API"
-  s.authors     = ["http://developer.paypal.com"]
-  s.email       = 'dl-paypal-checkout-api@paypal.com'
-  s.files       = Dir.glob ["lib/**/*.{rb}", "spec/**/*", "*.gemspec"]
-  s.homepage    =
-    'https://github.com/paypal/Checkout-Ruby-SDK'
-  s.license       = 'MIT'
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'core/version'
 
-  s.add_dependency 'braintreehttp', '~> 0.5.0'
+Gem::Specification.new do |spec|
+  spec.name        = 'paypal-checkout-sdk'
+  spec.version     = PayPal::VERSION
+  spec.summary     = "This repository contains PayPal's Ruby SDK for Checkout REST API"
+  spec.description = "This repository contains PayPal's Ruby SDK for Checkout REST API"
+  spec.authors     = ["http://developer.paypal.com"]
+  spec.email       = 'dl-paypal-checkout-api@paypal.com'
+  spec.homepage    = 'https://github.com/paypal/Checkout-Ruby-SDK'
+  spec.license     = 'MIT'
 
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'webmock'
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'braintreehttp', '~> 0.5'
+
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
Moved the declaration of dependencies into the gemspec, so that Rubygems and Bundler can properly understand the dependency graph.

Also modified the gemspec to look like those created by Bundler, which means not having to edit that file for every release and ensuring that the `PayPal::Version` constant stays in sync with the gem version.