### PR TITLE
Time.now returns value in seconds

### DIFF
--- a/lib/core/access_token.rb
+++ b/lib/core/access_token.rb
@@ -5,7 +5,7 @@ module PayPal
     def initialize(options)
       @access_token = options.access_token
       @token_type = options.token_type
-      @expires_in = options.expires_in * 1000
+      @expires_in = options.expires_in
       @date_created = Time.now
     end
 


### PR DESCRIPTION
Hello,

`BraintreeHttp::HttpError` occurred while using this SDK. It seems that the access token expiration could not be handled properly. Could you please review and merge the changes? I tested locally and also [the official document](https://developer.paypal.com/docs/api/get-an-access-token-curl/) says that the `expires_in` will be returned in seconds, the same as Ruby's `Time.now`.

Thanks!