### PR TITLE
Update example with correct header value for paypal-debug-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ begin
 rescue PayPalHttp::HttpError => ioe
     # Something went wrong server-side
     puts ioe.status_code
-    puts ioe.headers["debug_id"]
+    puts ioe.headers["paypal-debug-id"]
 end
 ```
 


### PR DESCRIPTION
### Purpose

The README for outputting Paypal's debug id on error responses seems to incorrect.

The headers from the exception look like:
```
{"cache-control"=>["max-age=0, no-cache, no-store, must-revalidate"], "content-length"=>["584"], "content-type"=>["application/json"], "date"=>["Tue, 04 Aug 2020 22:40:54 GMT"], "paypal-debug-id"=>["ab923eb27a806"]}
```

### Changes

Update example with correct header value for paypal-debug-id

### Testing

Tested locally.