### PR TITLE
Use SPDX identifier for gem license

### DIFF
--- a/paypal-checkout-sdk.gemspec
+++ b/paypal-checkout-sdk.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.authors     = ["http://developer.paypal.com"]
   spec.email       = 'dl-paypal-checkout-api@paypal.com'
   spec.homepage    = 'https://github.com/paypal/Checkout-Ruby-SDK'
-  spec.license     = 'https://github.com/paypal/Checkout-Ruby-SDK/blob/master/LICENSE'
+  spec.license     = 'Apache-2.0'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
The current SDK `.gemspec` uses a URL in the `license` attribute. The [rubygems specification reference](https://guides.rubygems.org/specification-reference/#license=) recommends using the correct SPDX identifier. This PR fixes this issue and thereby enables other system (e.g. license checking services) to identify the license of this gem.